### PR TITLE
Set tab and indent width to 2 spaces in project settings

### DIFF
--- a/Iconizer.xcodeproj/project.pbxproj
+++ b/Iconizer.xcodeproj/project.pbxproj
@@ -109,7 +109,9 @@
 				8EBD6F4B1B5449CF0062D62C /* Frameworks */,
 				8E3F8F661B23488F0096E9EC /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		8E3F8F661B23488F0096E9EC /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
I noticed you're using 2 spaces for indentation. It would be good to set this in the project settings so when others open it using Xcode, they can edit the files inside the project while having 2 spaces for indentation by default (Especially since the default is 4 spaces).
