### PR TITLE
Resolves: #6 Images generated are double in size.  Modified to use in…

### DIFF
--- a/Iconizer/Helper/NSImageExtensions.swift
+++ b/Iconizer/Helper/NSImageExtensions.swift
@@ -25,7 +25,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
 import Cocoa
 
 extension NSImage {
@@ -49,7 +48,6 @@ extension NSImage {
     return nil
   }
 
-
   // MARK: Resizing
 
   ///  Returns a new image that represents the original image after
@@ -60,7 +58,7 @@ extension NSImage {
   ///  - returns: The resized copy of the original image.
   func imageByCopyingWithSize(_ size: NSSize) -> NSImage? {
     // Create a new rect with given width and height
-    let frame = NSMakeRect(0, 0, size.width, size.height)
+    let frame = NSRect(x: 0, y: 0, width: size.width, height: size.height)
 
     // Get the best representation for the given size.
     guard let rep = self.bestRepresentation(for: frame, context: nil, hints: nil) else {
@@ -68,18 +66,17 @@ extension NSImage {
     }
 
     // Create an empty image with the given size.
-    let img = NSImage(size: size)
+    let img = NSImage(size: size, flipped: false, drawingHandler: { (dstRect: NSRect) -> Bool in
 
-    // Set the drawing context and make sure to remove the focus before returning.
-    defer { img.unlockFocus() }
-    img.lockFocus()
+        if rep.draw(in: frame) {
+            return true
+        }
 
-    // Draw the new image
-    if rep.draw(in: frame) {
-      return img
-    }
-    // Return nil in case something went wrong.
-    return nil
+        return false
+    })
+
+    return img
+
   }
 
   ///  Copies the current image and resizes it to the size of the given NSSize, while
@@ -104,7 +101,6 @@ extension NSImage {
 
     return self.imageByCopyingWithSize(newSize)
   }
-
 
   // MARK: Cropping
 
@@ -148,7 +144,6 @@ extension NSImage {
     // Return nil in case anything fails.
     return nil
   }
-
 
   // MARK: Saving
 


### PR DESCRIPTION
Per the apple docs:

Drawing Offscreen Images Using a Block-Based Drawing Method to Support High Resolution Displays
If your app uses the lockFocus and unlockFocus methods of the NSImage class for offscreen drawing, consider using the method imageWithSize:flipped:drawingHandler: instead (available in OS X v10.8). If you use the lock focus methods for drawing, you can get unexpected results—either you’ll get a low resolution NSImage object that looks incorrect when drawn, or you’ll get a 2x image that has more pixels in its bitmap than you are expecting.

Using the imageWithSize:flipped:drawingHandler: method ensures you’ll get correct results under standard and high resolution. The drawing handler is a block that can be invoked whenever the image is drawn to, and on whatever thread the drawing occurs. You should make sure that any state you access within the block is done in a thread-safe manner.

The code in the block should be the same code that you would use between the lockFocus and unlockFocus methods. 
