### PR TITLE
Support Launch Screens and App Icons for new 2018 Apple devices

### DIFF
--- a/Iconizer/Resources/AppIcon_Watch.json
+++ b/Iconizer/Resources/AppIcon_Watch.json
@@ -29,6 +29,33 @@
     },
     {
       "idiom" : "watch",
+      "size" : "44x44",
+      "subtype" : "40mm",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "filename" : "watch_appLauncher-40mm@2x.png",
+      "expected-size" : "88"
+    },
+    {
+      "idiom" : "watch",
+      "size" : "108x108",
+      "subtype" : "44mm",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "filename" : "watch_quickLook-44mm@2x.png",
+      "expected-size" : "216"
+    },
+    {
+      "idiom" : "watch",
+      "size" : "50x50",
+      "subtype" : "44mm",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "filename" : "watch_appLauncher-44mm@2x.png",
+      "expected-size" : "100"
+    },
+    {
+      "idiom" : "watch",
       "size" : "24x24",
       "subtype" : "38mm",
       "role" : "notificationCenter",
@@ -52,15 +79,6 @@
       "scale" : "3x",
       "filename" : "watch_companionSettings-@3x.png",
       "expected-size" : "87"
-    },
-    {
-      "idiom" : "watch",
-      "size" : "44x44",
-      "subtype" : "42mm",
-      "role" : "longLook",
-      "scale" : "2x",
-      "filename" : "watch_longLook-42mm@2x.png",
-      "expected-size" : "88"
     },
     {
       "idiom" : "watch",

--- a/Iconizer/Resources/LaunchImage_iPhone_Landscape.json
+++ b/Iconizer/Resources/LaunchImage_iPhone_Landscape.json
@@ -3,6 +3,28 @@
         {
             "extent" : "full-screen",
             "idiom" : "iphone",
+            "subtype" : "2688h",
+            "filename" : "iPhone-Landscape-2688h@3x.png",
+            "minimum-system-version" : "12.0",
+            "orientation" : "landscape",
+            "scale" : "3x",
+            "expected-width": "2688",
+            "expected-height": "1242"
+        },
+        {
+            "extent" : "full-screen",
+            "idiom" : "iphone",
+            "subtype" : "1792h",
+            "filename" : "iPhone-Landscape-1792h@2x.png",
+            "minimum-system-version" : "12.0",
+            "orientation" : "landscape",
+            "scale" : "2x",
+            "expected-width": "1792",
+            "expected-height": "828"
+        },
+        {
+            "extent" : "full-screen",
+            "idiom" : "iphone",
             "subtype" : "2436h",
             "filename" : "iPhone-Landscape-2436h@3x.png",
             "minimum-system-version" : "11.0",

--- a/Iconizer/Resources/LaunchImage_iPhone_Portrait.json
+++ b/Iconizer/Resources/LaunchImage_iPhone_Portrait.json
@@ -3,6 +3,28 @@
         {
             "extent" : "full-screen",
             "idiom" : "iphone",
+            "subtype" : "2688h",
+            "filename" : "iPhone-Portrait-2688h@3x.png",
+            "minimum-system-version" : "12.0",
+            "orientation" : "portrait",
+            "scale" : "3x",
+            "expected-width": "1242",
+            "expected-height": "2688"
+        },
+        {
+            "extent" : "full-screen",
+            "idiom" : "iphone",
+            "subtype" : "1792h",
+            "filename" : "iPhone-Portrait-1792h@2x.png",
+            "minimum-system-version" : "12.0",
+            "orientation" : "portrait",
+            "scale" : "2x",
+            "expected-width": "828",
+            "expected-height": "1792"
+        },
+        {
+            "extent" : "full-screen",
+            "idiom" : "iphone",
             "subtype" : "2436h",
             "filename" : "iPhone-Portrait-2436h@3x.png",
             "minimum-system-version" : "11.0",


### PR DESCRIPTION
Added Launch Screens in portrait and landscape for iPhone XR and XS Max.
Added new App Icon sizes for Apple Watch Series 4 and removed an old size, which is not recognized by Xcode anymore because it has been replaced.

The generated .appiconset and .launchimage asset catalogs have been tested and verified with Xcode 10.0 (10A255) 