### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Visit the [homepage](https://raphaelhanneken.com/iconizer/) for more information
 1. Download the latest [release](https://github.com/raphaelhanneken/Iconizer/releases) and drop into your Application's folder.
 2. Download the source code and it compile yourself.
     - You will need [Carthage](https://github.com/Carthage/Carthage) for this, to install Sparkle.
-3. Via Homebrew Cask `brew cask install iconizer`
+3. Via Homebrew Cask `brew install --cask iconizer`
 
 
 


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103323358-d46dbf00-4a85-11eb-8816-b67d767c58dd.png)
